### PR TITLE
Add test for pr346

### DIFF
--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -169,15 +169,27 @@ def test_get_seaton_phixs_table(threshold_energy_ryd, fit_coeff_list):
 
 
 @pytest.mark.array_compare
-@pytest.mark.parametrize("hyd_gaunt_energy_grid_ryd", [{1: list(range(1, 3))}])
+@pytest.mark.parametrize("hyd_gaunt_energy_grid_ryd", [{1: list(range(1, 4))}])
 @pytest.mark.parametrize("hyd_gaunt_factor", [{1: list(range(3, 6))}])
 @pytest.mark.parametrize("threshold_energy_ryd", [0.5])
 @pytest.mark.parametrize("n", [1])
+@pytest.mark.parametrize("hyd_n_phixs_stop2start_energy_ratio", [20])
+@pytest.mark.parametrize("hyd_n_phixs_num_points", [20])
 def test_get_hydrogenic_n_phixs_table(
-    hyd_gaunt_energy_grid_ryd, hyd_gaunt_factor, threshold_energy_ryd, n
+    hyd_gaunt_energy_grid_ryd,
+    hyd_gaunt_factor,
+    threshold_energy_ryd,
+    n,
+    hyd_n_phixs_stop2start_energy_ratio,
+    hyd_n_phixs_num_points,
 ):
     hydrogenic_n_phixs_table = get_hydrogenic_n_phixs_table(
-        hyd_gaunt_energy_grid_ryd, hyd_gaunt_factor, threshold_energy_ryd, n
+        hyd_gaunt_energy_grid_ryd,
+        hyd_gaunt_factor,
+        threshold_energy_ryd,
+        n,
+        hyd_n_phixs_stop2start_energy_ratio,
+        hyd_n_phixs_num_points,
     )
     return hydrogenic_n_phixs_table
 


### PR DESCRIPTION
Added tests for carsus pr346.

**Description**
Added hyd_n_phixs_stop2start_energy_ratio and hyd_n_phixs_num_points to the function hydrogenic_n_phixs_table.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
